### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+.venv/
 .pipenv
 .west/
 Pipfile
@@ -9,3 +10,6 @@ linux-guest/
 linux-host/
 tdvf/
 smatch/
+fuzz.sh
+TDVF.fd
+initrd.cpio.gz

--- a/bkc/syzkaller/build/.gitignore
+++ b/bkc/syzkaller/build/.gitignore
@@ -1,0 +1,2 @@
+qemu-4.2.0.tar.xz
+qemu-4.2.0/


### PR DESCRIPTION
- Update root gitignore to exclude some files used by fuzz.sh
- create gitignore in `bkc/syzcaller/build` to ignore QEMU build