### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ automated/fast coverage collection can be enabled using `-c`.
 To run the configured harnesses and store the resulting data in the folder `~/results`:
 
 ```shell
-./bkc/kafl/run_experiments.py run -c -p 4 $LINUX_GUEST ~/results
+./bkc/kafl/run_experiments.py -p 4 run -c $LINUX_GUEST ~/results
 ```
 
 Note: Coverage collection uses Ghidra to reconstruct full traces from PT dumps.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For additional background, see [applying code audit results](https://intel.githu
 ```shell
 make -C $LINUX_GUEST prepare
 make -C ./bkc/audit
-mv smatch_warns_annotated.txt $LINUX_GUEST/smatch_warns.txt
+mv $LINUX_GUEST/smatch_warns_annotated.txt $LINUX_GUEST/smatch_warns.txt
 ```
 
 Note that the `annotated` smatch report is moved to `smatch_warns.txt`,


### PR DESCRIPTION
small fixes in the https://github.com/intel/ccc-linux-guest-hardening#batch-running-campaigns-and-smatch-coverage section

About the run_experiments command line change, the parallel parameter is used in the main_parser
https://github.com/intel/ccc-linux-guest-hardening/blob/master/bkc/kafl/run_experiments.py#L499