### PR TITLE
always pull guest kernel but don't build

### DIFF
--- a/deploy/roles/guest/tasks/build.yml
+++ b/deploy/roles/guest/tasks/build.yml
@@ -1,0 +1,18 @@
+- name: Copy BKC TDX guest kernel config
+  copy:
+    src: "{{ playbook_dir | dirname }}/bkc/kafl/linux_kernel_tdx_guest.config"
+    dest: "{{ guest_root }}/.config"
+
+- name: Enable Virtio harness
+  command: "{{ item }}"
+  args:
+    chdir: "{{ guest_root }}"
+  with_items:
+    - ./scripts/config -e CONFIG_TDX_FUZZ_KAFL
+    - ./scripts/config -e CONFIG_TDX_FUZZ_HARNESS_DOINITCALLS_VIRTIO
+
+- name: Build TDX guest kernel
+  make:
+    chdir: "{{ guest_root }}"
+    params:
+      --jobs: "{{ ansible_processor_nproc }}"

--- a/deploy/roles/guest/tasks/main.yml
+++ b/deploy/roles/guest/tasks/main.yml
@@ -16,3 +16,9 @@
     version: "{{ guest_revision | default(omit) }}"
     depth: "{{ git_clone_depth | default(omit) }}"
     force: yes
+
+- name: Prepare fuzzing build of TDX guest kernel
+  include_tasks: build.yml
+  tags:
+      - guest_build
+      - never

--- a/deploy/roles/guest/tasks/main.yml
+++ b/deploy/roles/guest/tasks/main.yml
@@ -16,22 +16,3 @@
     version: "{{ guest_revision | default(omit) }}"
     depth: "{{ git_clone_depth | default(omit) }}"
     force: yes
-
-- name: Copy BKC TDX guest kernel config
-  copy:
-    src: "{{ playbook_dir | dirname }}/bkc/kafl/linux_kernel_tdx_guest.config"
-    dest: "{{ guest_root }}/.config"
-
-- name: Enable Virtio harness
-  command: "{{ item }}"
-  args:
-    chdir: "{{ guest_root }}"
-  with_items:
-    - ./scripts/config -e CONFIG_TDX_FUZZ_KAFL
-    - ./scripts/config -e CONFIG_TDX_FUZZ_HARNESS_DOINITCALLS_VIRTIO
-
-- name: Build TDX guest kernel
-  make:
-    chdir: "{{ guest_root }}"
-    params:
-      --jobs: "{{ ansible_processor_nproc }}"

--- a/deploy/roles/guest/tasks/main.yml
+++ b/deploy/roles/guest/tasks/main.yml
@@ -18,7 +18,7 @@
     force: yes
 
 - name: Prepare fuzzing build of TDX guest kernel
-  include_tasks: build.yml
+  import_tasks: build.yml
   tags:
       - guest_build
       - never

--- a/deploy/site.yml
+++ b/deploy/site.yml
@@ -30,7 +30,6 @@
     - role: guest
       tags:
         - guest
-        - never
     - role: smatch
       tags:
         - smatch


### PR DESCRIPTION
Always pull linux-guest so we have something to work with.
Only leave configure/build to the user workflow.