### PR TITLE
Expose environment with explicit env.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,7 @@
-.env
-.venv/
-.pipenv
-.west/
-venv/
+env.sh
+/deploy/venv/
 Pipfile
 Pipfile.lock
-manifest/
 /kafl/
 linux-guest/
 linux-host/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # Makefile recipies for managing kAFL workspace
 
 # declare all targets in this variable
-ALL_TARGETS:=deploy clean
+ALL_TARGETS:=deploy clean env
 # declare all target as PHONY
 .PHONY: $(ALL_TARGETS)
 

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,8 @@ deploy:
 
 clean:
 	make -C deploy $@
+
+env: SHELL:=bash
+env: env.sh
+	@echo "Entering environment in sub-shell. Exit with 'Ctrl-d'."
+	@PROMPT_COMMAND='source env.sh; unset PROMPT_COMMAND' $(SHELL)

--- a/deploy/site.yml
+++ b/deploy/site.yml
@@ -44,4 +44,4 @@
     - name: Install env file
       template:
         src: env.j2
-        dest: "{{ install_root }}/.env"
+        dest: "{{ install_root }}/env.sh"

--- a/deploy/templates/env.j2
+++ b/deploy/templates/env.j2
@@ -1,3 +1,5 @@
+# source this file to activate the shell+python environment
+
 export BKC_ROOT="{{ install_root }}"
 export LINUX_GUEST="{{ guest_root }}"
 export LINUX_HOST=""
@@ -13,3 +15,6 @@ export RADAMSA_ROOT="{{ radamsa_root }}"
 export PACKER_ROOT="{{ nyx_packer_root }}"
 export KAFL_CONFIG_FILE="{{ install_root }}/bkc/kafl/kafl_config.yaml"
 export KAFL_WORKDIR="/dev/shm/{{ ansible_user_id }}_tdfl"
+
+# activate python venv
+source $KAFL_ROOT/.venv/bin/activate


### PR DESCRIPTION
Turned out easier than expected. Generate env.sh directly that works for source + deactivate. The KAFL_ROOT etc variables remain active this way (similar to sourcing via --input-file).

Added a makefile recipe which uses this to a subshell again. I think that takes best of both worlds
- old behavior remains intact and environment is confined to subshell
- sourcing the env.sh also allows to non-interactively launch scripts, i.e. source env.sh && bkc/kafl/foo/bar
- default PS1 is ugly but can customize..