### PR TITLE
deploy: source kafl env vars

### DIFF
--- a/deploy/templates/env.j2
+++ b/deploy/templates/env.j2
@@ -1,20 +1,14 @@
 # source this file to activate the shell+python environment
 
+# sourcing kAFL env
+source "{{ kafl_install_root }}/env.sh"
+
+# override some kafl env vars
+export KAFL_CONFIG_FILE="{{ install_root }}/bkc/kafl/kafl_config.yaml"
+
+# add CCC repo env vars
 export BKC_ROOT="{{ install_root }}"
 export LINUX_GUEST="{{ guest_root }}"
 export LINUX_HOST=""
 export TDVF_ROOT="{{ tdvf_root }}"
 export SMATCH_ROOT="{{ smatch_root }}"
-
-# kafl baseline
-export KAFL_ROOT="{{ kafl_install_root }}"
-export QEMU_ROOT="{{ qemu_root }}"
-export LIBXDC_ROOT="{{ libxdc_root }}"
-export CAPSTONE_ROOT="{{ capstone_root }}"
-export RADAMSA_ROOT="{{ radamsa_root }}"
-export PACKER_ROOT="{{ nyx_packer_root }}"
-export KAFL_CONFIG_FILE="{{ install_root }}/bkc/kafl/kafl_config.yaml"
-export KAFL_WORKDIR="/dev/shm/{{ ansible_user_id }}_tdfl"
-
-# activate python venv
-source $KAFL_ROOT/.venv/bin/activate


### PR DESCRIPTION
This PR is based on https://github.com/IntelLabs/kAFL/pull/110

It's sourcing the kafl's `env.sh` instead of recreating it from scratch, and overriding one variable: `KAFL_CONFIG_FILE`