### PR TITLE
deploy: remove explicit inclusion of kafl.nyx_packer role

### DIFF
--- a/deploy/site.yml
+++ b/deploy/site.yml
@@ -19,10 +19,7 @@
         # install kafl in its own subdir
         # can't reuse install_root because of jinja templating recursion issue
         kafl_install_root: "{{ playbook_dir | dirname if ansible_connection == 'local' else ansible_env.HOME + '/ccc'}}/kafl"
-
-    - role: intellabs.kafl.nyx_packer
-      tags:
-        - nyx_packer
+        install_nyx_packer: true
 
     - role: tdvf
       tags:


### PR DESCRIPTION
Solves: `make prepare` leads to `Fatal error: Invalid directory: $HTOOLS_ROOT=/packer/linux_x86_64-userspace/` because `PACKER_ROOT` is not defined.

Requires https://github.com/IntelLabs/kAFL/pull/113