### PR TITLE
ensure qemu-utils are installed

### DIFF
--- a/deploy/roles/bkc/tasks/main.yml
+++ b/deploy/roles/bkc/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: Install BKC system dependencies
   package:
     name:
+      - qemu-utils     # for qemu-img
       - busybox-static # to generate initrd
       - elfutils       # for eu-addr2line
       - cargo          # fast_matcher


### PR DESCRIPTION
```console
$ make prepare
BASH_ENV=env.sh bash bkc/kafl/userspace/gen_sharedir.sh sharedir
BASH_ENV=env.sh bash bkc/kafl/userspace/gen_initrd.sh initrd_busybox.cpio.gz
qemu-img create -f qcow2 disk.img 1024M
make: qemu-img: No such file or directory
```

We don't strictly depend on it but maybe this dependency should go on the parent kAFL/fuzzer role..
