### PR TITLE
cosmetics: rename target to output, silence missing variable error

### DIFF
--- a/bkc/audit/smatch_audit.sh
+++ b/bkc/audit/smatch_audit.sh
@@ -3,7 +3,7 @@
 #
 # Perform smatch analysis on linux kernel
 #
-# Cleans + builds the kernel at $LINUX_GUEST and copies smatch reports to provided target dir.
+# Cleans + builds the kernel at $LINUX_GUEST and copies smatch reports to provided output dir.
 #
 
 set -e
@@ -17,7 +17,7 @@ function usage()
 Usage: $0 <dir> <config>
 
 Where:
-  <target>  - output directory for storing smatch results
+  <output>  - output directory for storing smatch results
   <config>  - kernel config to be used in build/audit
 HERE
 	exit
@@ -53,8 +53,8 @@ analyze_kernel()
 	$SMATCH_FILTER --force -o $SMATCH_FILTERED $SMATCH_WARNS
 	$SMATCH_TRANSFER --force -o $SMATCH_TRANSFERRED $SMATCH_ANNOTATED $SMATCH_FILTERED
 
-	cp $SMATCH_WARNS $SMATCH_LOG $TARGET_DIR/
-	cp $SMATCH_FILTERED $SMATCH_TRANSFERRED $TARGET_DIR/
+	cp $SMATCH_WARNS $SMATCH_LOG $OUTPUT_DIR/
+	cp $SMATCH_FILTERED $SMATCH_TRANSFERRED $OUTPUT_DIR/
 }
 
 # Helpers
@@ -78,7 +78,7 @@ test -f $SMATCH_BIN    || fail "Could not find $SMATCH_BIN - try to 'make deploy
 test "$#" -eq 2        || usage "Bad or missing arguments"
 
 
-TARGET_DIR="$(realpath -e -- "$1")"; shift
+OUTPUT_DIR="$(realpath -e -- "$1")"; shift
 CONFIG_NEW="$(realpath -e -- "$1")"; shift
 CONFIG_OLD="$LINUX_GUEST/.config"
 

--- a/bkc/kafl/fuzz.sh
+++ b/bkc/kafl/fuzz.sh
@@ -41,7 +41,7 @@ else
 fi
 
 # virtfs needs some default folder to serve to guest
-test -d /tmp/kafl || mkdir /tmp/kafl
+test -d /tmp/kafl || mkdir -p /tmp/kafl
 
 function usage()
 {

--- a/bkc/kafl/fuzz.sh
+++ b/bkc/kafl/fuzz.sh
@@ -344,7 +344,7 @@ function build_harness()
 
 function smatch_match()
 {
-	if test $USE_FAST_MATCHER -gt 0; then
+	if test "0$USE_FAST_MATCHER" -gt 0; then
 		$BKC_ROOT/bkc/coverage/fast_matcher/target/release/fast_matcher -p $(nproc) -f -a -s $WORK_DIR/target/smatch_warns.txt $WORK_DIR > $WORK_DIR/traces/linecov.lst
 		# Make paths relative
 		$BKC_ROOT/bkc/coverage/strip_addr2line_absolute_path.sh $WORK_DIR/target/vmlinux $WORK_DIR/traces/linecov.lst


### PR DESCRIPTION
- <target> is already used everywhere and easy to misunderstand...
- avoid failing `test` statement when USE_FAST_SMATCHER is unset