### PR TITLE
ci: add basic static analysis for python with flake8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,23 @@ jobs:
           --skip-tags "hardware_check,kvm_device,update_grub,reboot_kernel"
           --extra-vars "@parameters.json"
   
+  lint-python:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+          cache: 'pip'
+
+      - name: install flake8
+        run: pip install flake8==5.0.4
+
+      # select:
+      #   F841 local variable 'xxx' is assigned to but never used
+      #   F541 f-string is missing placeholders
+      #   F401 'xxx' imported but unused
+      - name: Lint python code
+        run: find bkc -name '*.py' -not -path '*venv*' -not -path '*qemu-4.2.0/*' -exec flake8 --statistics --select=F541,F401,F841 {} \;

--- a/bkc/audit/process_smatch_output.py
+++ b/bkc/audit/process_smatch_output.py
@@ -8,7 +8,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-import os, sys, string, re, argparse
+import os, sys, re, argparse
 
 smatch_pattern_name = "check_host_input"
 

--- a/bkc/audit/transfer_results.py
+++ b/bkc/audit/transfer_results.py
@@ -8,7 +8,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-import os, sys, string, re, argparse
+import os, sys, re, argparse
 
 
 def main(args):
@@ -124,7 +124,7 @@ if __name__ == "__main__":
     parser.add_argument('-o', '--output_file', metavar='<output_file>', type=str, default="smatch_warns.txt.analyzed",
             help='Store output to specified file')
     parser.add_argument('-f', '--force', action="store_true",
-            help=f'Force overwrite existing output files')
+            help='Force overwrite existing output files')
     parser.add_argument('-t', action="store_true",
             help='Store intermediate files for debugging (.tmp.new, .tmp.old).')
     args = parser.parse_args()

--- a/bkc/coverage/smatcher/setup.py
+++ b/bkc/coverage/smatcher/setup.py
@@ -1,15 +1,17 @@
 from setuptools import setup
 from smatcher import __version__, __license__, __author__, __email__
 
-setup(name='smatcher',
-      version=__version__,
-      description='Smatcher - line coverage smatch analysis and aggregation tool',
-      url='https://github.com/intel/ccc-linux-guest-hardening',
-      author=__author__,
-      author_email=__email__,
-      license=__license__,
-      packages=['smatcher'],
-      entry_points = {
-        'console_scripts': ['smatcher=smatcher.__init__:main'],
-      },
-      zip_safe=False)
+setup(
+  name='smatcher',
+  version=__version__,
+  description='Smatcher - line coverage smatch analysis and aggregation tool',
+  url='https://github.com/intel/ccc-linux-guest-hardening',
+  author=__author__,
+  author_email=__email__,
+  license=__license__,
+  packages=['smatcher'],
+  entry_points={
+    'console_scripts': ['smatcher=smatcher.__init__:main'],
+  },
+  zip_safe=False
+)

--- a/bkc/coverage/smatcher/smatcher/__init__.py
+++ b/bkc/coverage/smatcher/smatcher/__init__.py
@@ -87,7 +87,7 @@ def try_find_smatch_file(args, input_item):
     # Treat as linecov input
     if os.path.isfile(input_item) and args.smatch is None:
         #TODO: add default global/ cwd smatch file??
-        print(f"Could not auto-detect smatch file. Please set '--smatch' parameter", file=sys.stderr)
+        print("Could not auto-detect smatch file. Please set '--smatch' parameter", file=sys.stderr)
         sys.exit(1)
 
     # Treat as kAFL workdir
@@ -332,17 +332,17 @@ def main():
     parser.add_argument('--combine-cov-files', action="store_true",
             help=f'use the combined coverage of the files {LINECOV_FILES}')
     parser.add_argument('--ignore-errors', action="store_true",
-            help=f'do not exit on errors')
+            help='do not exit on errors')
     parser.add_argument('--smatch-reachability-db-file', metavar='<db_file>', type=str, default=SMATCH_REACHABILITY_DB_FILE,
             help=f'Global db file to use. Defaults to {GLOBAL_DB_FILE}')
     parser.add_argument('--db-file', metavar='<db_file>', type=str, default=GLOBAL_DB_FILE,
             help=f'Global db file to use. Defaults to {GLOBAL_DB_FILE}')
     parser.add_argument('--save', action="store_true",
-            help=f'save coverage in global db')
+            help='save coverage in global db')
     parser.add_argument('--load', action="store_true",
-            help=f'load earlier coverage from global db')
+            help='load earlier coverage from global db')
     parser.add_argument('--reachability', action="store_true",
-            help=f'do reachability analysis on results. Requires smatch_db.sqlite in your current dir (generated using smatch_scripts/build_kernel_data.sh)')
+            help='do reachability analysis on results. Requires smatch_db.sqlite in your current dir (generated using smatch_scripts/build_kernel_data.sh)')
 
     args = parser.parse_args()
 

--- a/bkc/kafl/init_harness.py
+++ b/bkc/kafl/init_harness.py
@@ -8,14 +8,13 @@
 #
 # SPDX-License-Identifier: MIT
 
-import re
 import os
 import sys
 import shutil
 import argparse
 import yaml
 
-from pprint import pprint, pformat
+from pprint import pformat
 
 boot_harnesses = [
         "BOOT_POST_TRAP",
@@ -277,7 +276,7 @@ def parse_args():
     # pre-process harness pattern before complaining about output path..
     selected = list()
     if args.harness in ["help", "list"]:
-        sys.exit(f"Supported harnesses:\n%s" % pformat(HARNESSES))
+        sys.exit("Supported harnesses:\n%s" % pformat(HARNESSES))
 
     if args.harness == "all":
         selected = HARNESSES

--- a/bkc/kafl/pipeline.py
+++ b/bkc/kafl/pipeline.py
@@ -26,10 +26,8 @@
 import os
 import sys
 
-import glob
 import tempfile
 import argparse
-import shutil
 import time
 import subprocess
 
@@ -38,8 +36,7 @@ from pathlib import Path
 from pprint import pformat
 
 import parsl
-from parsl.app.app import python_app, bash_app
-from parsl.data_provider.files import File
+from parsl.app.app import python_app
 
 from parsl.config import Config
 from parsl.executors.threads import ThreadPoolExecutor
@@ -135,7 +132,6 @@ def task_fuzz(args, pipe_id, harness_dir, target_dir, work_dir):
 @python_app
 def task_trace(args, harness_dir, work_dir):
 
-    import os
     import subprocess
 
     logfile = work_dir/'task_trace.log'
@@ -173,7 +169,6 @@ def task_smatch(args, work_dir, smatch_list, wait_task=None):
 @python_app
 def task_triage(args):
 
-    import os
     import subprocess
 
     # generate stats output
@@ -350,10 +345,10 @@ def main():
         harness_dirs.append(harness.parent)
 
     if len(harness_dirs) < 1:
-        sys.exit(f"No matching harnesses found in campaign root. Abort.")
+        sys.exit("No matching harnesses found in campaign root. Abort.")
 
     print(f"Setup campaign root at {args.campaign_root}")
-    print(f"Scheduled for execution:\n%s" % pformat([str(h) for h in harness_dirs]))
+    print("Scheduled for execution:\n%s" % pformat([str(h) for h in harness_dirs]))
 
 
     # for few CPUs, use single pipes and all available cores
@@ -385,7 +380,7 @@ def main():
     if args.dry_run:
         args.kafl_extra = ["--abort-exec", "500"]
 
-    print(f"\nExecuting %d harnesses in %d pipelines (%d workers, %d threads, %d cpus).\n" % (
+    print("\nExecuting %d harnesses in %d pipelines (%d workers, %d threads, %d cpus).\n" % (
         len(harness_dirs), args.pipes, args.workers, args.threads, args.ncpu))
 
     for i in "321":

--- a/bkc/kafl/smatch_match.py
+++ b/bkc/kafl/smatch_match.py
@@ -18,22 +18,15 @@ import sys
 
 import time
 import glob
-import shutil
 import msgpack
 import lz4.frame as lz4
 import re
-import signal
 import multiprocessing as mp
 
-from tqdm import trange, tqdm
 from operator import itemgetter
-from math import ceil
 
-import json
-import csv
 
 import argparse
-import pickle
 
 def read_binary_file(filename):
     with open(filename, 'rb') as f:
@@ -326,7 +319,6 @@ class TraceParser:
 
     def callsite_trace_func(self, func, levels=4):
         # for known IPs in a function, build the unique set of caller IPs and trace them
-        callers = set()
         addrs = self.func2addrs(func)
         for addr in addrs:
             #print("trace_by_func(%s) -> %016x" % (func, addr))
@@ -468,7 +460,7 @@ def main():
                 if not m:
                     continue
                 lino = m.group(1)
-                func = m.group(2)
+                # func = m.group(2)
 
                 #func2lino.setdefault(func, set()).add(lino)
                 #lino2func[lino] = func
@@ -488,7 +480,6 @@ def main():
 
     args = parser.parse_args()
 
-    nproc = min(args.p, os.cpu_count())
     trace_dir = args.work_dir + "/traces"
 
     if not os.path.isdir(trace_dir):

--- a/bkc/kafl/stats.py
+++ b/bkc/kafl/stats.py
@@ -5,15 +5,12 @@
 import os
 import sys
 
-import glob
 import msgpack
 import argparse
 import subprocess
 
 from pathlib import Path
-from pprint import pprint
 
-from time import strftime
 from datetime import timedelta
 
 import humanize
@@ -186,7 +183,6 @@ def stats_aggregate(stats):
             ret[fav][state] = ret[fav].get(state, 0) + 1
 
     for method, num in stats['yield'].items():
-        name=methods[method]
         ret['yield'][methods[method]] = num
 
     stats['aggregate'] = ret


### PR DESCRIPTION
This PR adds some static analysis for Python code in the ccc repo with `flake8`.

Given the amount of lint errors, i only selected 3 of them for now:
~~~
      # select:
      #   F841 local variable 'xxx' is assigned to but never used
      #   F541 f-string is missing placeholders
      #   F401 'xxx' imported but unused
~~~

The rest can be enabled later on, warning by warning