### PR TITLE
[WIP] fix/harness doinitcall any

### DIFF
--- a/bkc/kafl/init_harness.py
+++ b/bkc/kafl/init_harness.py
@@ -123,7 +123,8 @@ harness_options = {
     "BOOT_DOINITCALLS_VIRTIO": {"CONFIG_TDX_FUZZ_KAFL_VIRTIO": "y"},
     "BOOT_DOINITCALLS_PCI": {"CONFIG_TDX_FUZZ_KAFL_SKIP_ACPI_PIO": "y"},
     "BOOT_START_KERNEL": {"CONFIG_TDX_FUZZ_KAFL_SKIP_ACPI_PIO": "y"},
-    "CONFIG_TDX_FUZZ_HARNESS_DOINITCALLS": {"CONFIG_TDX_FUZZ_KAFL_SKIP_IOAPIC_READS": "y", "CONFIG_TDX_FUZZ_KAFL_SKIP_ACPI_PIO": "y"},
+    "DOINITCALLS_LEVEL_ANY": {"CONFIG_TDX_FUZZ_KAFL_SKIP_IOAPIC_READS": "y",
+                              "CONFIG_TDX_FUZZ_KAFL_SKIP_ACPI_PIO": "y"},
     "DOINITCALLS_LEVEL_7": {"CONFIG_TDX_FUZZ_KAFL_VIRTIO": "y"},
     "DOINITCALLS_LEVEL_6": {"CONFIG_TDX_FUZZ_KAFL_VIRTIO": "y"},
     "BPH_VIRTIO_CONSOLE_INIT": {"CONFIG_TDX_FUZZ_KAFL_VIRTIO": "y"},
@@ -166,6 +167,7 @@ def generate_setups(args, harness):
         req_conf.update({f"CONFIG_TDX_FUZZ_HARNESS_{basename}": "y"})
     elif harness.startswith("DOINITCALLS_LEVEL"):
         level = harness[len("DOINITCALLS_LEVEL_"):]
+        req_conf.update(harness_options.get("DOINITCALLS_LEVEL_ANY", {}))
         req_conf.update({
             "CONFIG_TDX_FUZZ_HARNESS_DOINITCALLS": "y",
             "CONFIG_TDX_FUZZ_HARNESS_DOINITCALLS_LEVEL": level})


### PR DESCRIPTION
Should we disable ACPI + APIC PIO injection for DOINITCALLS_LEVEL_X harnesses?

Originally based on run_experiments.py and fixed in below: [b74441f](https://github.com/intel/ccc-linux-guest-hardening/pull/65/commits/b74441f1a4ee08e8ace4b24a61a6049d39acb564)
