### PR TITLE
smatcher: disable broken smdb import

### DIFF
--- a/bkc/coverage/smatcher/smatcher/__init__.py
+++ b/bkc/coverage/smatcher/smatcher/__init__.py
@@ -17,12 +17,14 @@ from itertools import groupby
 
 SMATCH_PATH = os.environ.get("SMATCH_PATH", os.path.expanduser("~/tdx/smatch"))
 smdb_available = False
-try:
-    sys.path.insert(0, os.path.join(SMATCH_PATH, "smatch_data/db"))
-    import smdb
-    smdb_available = True
-except Exception:
-    smdb_available = False
+
+# smatch smdb.py - broken
+#try:
+#    sys.path.insert(0, os.path.join(SMATCH_PATH, "smatch_data/db"))
+#    import smdb
+#    smdb_available = True
+#except Exception:
+#    smdb_available = False
 
 __author__ = "Sebastian Österlund <sebastian.osterlund@intel.com>"
 __email__ = "sebastian.osterlund@intel.com"


### PR DESCRIPTION
"import smdb" with path set to SMATCH_ROOT/smatch_data/db/ prints usage() and exits with failure. 
Also causes pip install to fail - why have we not seen this?

```
ERROR: Command errored out with exit status 1:                                                              
         command: /[...]/ccc-linux-guest-hardening/kafl/.venv/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/[....]/ccc-linux-guest-hardening/bkc/coverage/smatch
er/setup.py'"'"'; __file__='"'"'/[...]/ccc-linux-guest-hardening/bkc/coverage/smatcher/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'
"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-7g0llnpt 
             cwd: /[...]/ccc-linux-guest-hardening/bkc/coverage/smatcher/                                                
        Complete output (13 lines):                                                                                          
        /[...]/ccc-linux-guest-hardening/bkc/coverage/smatcher/setup.py                                                  
        <function> - how a function is called                                                                                
        info <type> - how a function is called, filtered by type                                                             
        return_states <function> - what a function returns                                                                   
        call_tree <function> - show the call tree                                                                            
        where <struct_type> <member> - where a struct member is set                                                          
        type_size <struct_type> <member> - how a struct member is allocated                                                  
        data_info <struct_type> <member> - information about a given data type                                               
        function_ptr <function> - which function pointers point to this                                                      
        trace_param <function> <param> - trace where a parameter came from                                                   
        find_tagged <function> <param> - find the source of a tagged value (arm64)                                           
        parse_warns_tagged <smatch_warns.txt> - parse warns file for summary of tagged issues (arm64)                        
        locals <file> - print the local values in a file.                                                                    
        ----------------------------------------                                               
    WARNING: Discarding file:///[...]ccc-linux-guest-hardening/bkc/coverage/smatcher. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command out
put.                                                                                                                         
    ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.                                                                            
                                                                                                                             
PLAY RECAP **************************************************************************                                        
localhost                  : ok=35   changed=6    unreachable=0    failed=1    skipped=13   rescued=0    ignored=0           
```