### PR TITLE
[smatcher] fix outdated annotated pathname

### DIFF
--- a/bkc/coverage/smatcher/smatcher/__init__.py
+++ b/bkc/coverage/smatcher/smatcher/__init__.py
@@ -101,7 +101,7 @@ def try_find_smatch_file(args, input_item):
     # Treat as kAFL workdir
     work_dir = input_item
     smatch_file = os.path.join(work_dir,
-                               "target/smatch_warns.txt_results_analyzed")
+                               "target/smatch_warns_annotated.txt")
     if os.path.isfile(smatch_file):
         return smatch_file
 

--- a/bkc/kafl/fuzz.sh
+++ b/bkc/kafl/fuzz.sh
@@ -164,6 +164,7 @@ function run()
 	pushd $TARGET_ROOT > /dev/null
 		cp .config $WORK_DIR/target/config
 		test -f smatch_warns.txt && cp smatch_warns.txt $WORK_DIR/target/smatch_warns.txt
+		test -f smatch_warns_annotated.txt && cp smatch_warns_annotated.txt $WORK_DIR/target/smatch_warns_annotated.txt
 		if git status > /dev/null; then
 			git log --pretty=oneline -4 > $WORK_DIR/target/repo_log
 			git diff > $WORK_DIR/target/repo_diff


### PR DESCRIPTION
Fixes an issue where the default setup does not use the annotated smatch results, giving no coverage of annotated items