### PR TITLE
ci: bump ansible-lint to v6.9.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: deploy
         run: |
           ./venv/bin/pip install wheel
-          ./venv/bin/pip install ansible-lint==6.3.0
+          ./venv/bin/pip install ansible-lint==6.9.1
 
       # ignore 'meta-no-info', since we don't need to publish our roles to Ansible Galaxy
       - name: Run ansible-lint

--- a/deploy/roles/guest/tasks/build.yml
+++ b/deploy/roles/guest/tasks/build.yml
@@ -14,7 +14,6 @@
   changed_when: false
 
 - name: Build TDX guest kernel
-  ansible.builtin.make:
+  community.general.system.make:
     chdir: "{{ guest_root }}"
-    params:
-      --jobs: "{{ ansible_processor_nproc }}"
+    jobs: "{{ ansible_processor_nproc }}"

--- a/deploy/roles/guest/tasks/main.yml
+++ b/deploy/roles/guest/tasks/main.yml
@@ -18,7 +18,7 @@
     force: true
 
 - name: Prepare fuzzing build of TDX guest kernel
-  import_tasks: build.yml
+  ansible.builtin.import_tasks: build.yml
   tags:
     - guest_build
     - never

--- a/deploy/roles/smatch/tasks/main.yml
+++ b/deploy/roles/smatch/tasks/main.yml
@@ -39,10 +39,9 @@
   changed_when: false
 
 - name: Build smatch
-  ansible.builtin.make:
+  community.general.system.make:
     chdir: "{{ smatch_root }}"
-    params:
-      --jobs: "{{ ansible_processor_nproc }}"
+    jobs: "{{ ansible_processor_nproc }}"
 
 - name: Delete patch file
   ansible.builtin.file:

--- a/deploy/roles/tdvf/tasks/build.yml
+++ b/deploy/roles/tdvf/tasks/build.yml
@@ -17,10 +17,9 @@
     force: true
 
 - name: Build BaseTools
-  ansible.builtin.make:
+  community.general.system.make:
     chdir: "{{ tdvf_root }}/BaseTools"
-    params:
-      --jobs: "{{ ansible_processor_nproc }}"
+    jobs: "{{ ansible_processor_nproc }}"
 
 - name: Build TDVF
   ansible.builtin.shell: >


### PR DESCRIPTION
fix #75 

Since ansible-lint v6.8.5