### PR TITLE
pin kafl stable repo

### DIFF
--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -2,4 +2,4 @@ collections:
   - name: intellabs.kafl
     source: git+https://github.com/IntelLabs/kAFL#/deploy/intellabs/
     type: git
-    version: master
+    version: stable-v0.5


### PR DESCRIPTION
Major update to upstream repo also impacted kAFL ansible collection, need to pin a stable version.