### PR TITLE
bkc: set KVM module parameters for ccc

### DIFF
--- a/deploy/roles/bkc/tasks/main.yml
+++ b/deploy/roles/bkc/tasks/main.yml
@@ -42,3 +42,12 @@
   when: not ansible_check_mode
   tags:
     - build
+
+- name: Update KVM module option to set VE injection
+  ansible.builtin.blockinfile:
+    path: /etc/modprobe.d/kvm-intel.conf
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - ccc-linux-guest-hardening"
+    block: |
+      options kvm-intel nested=1 ve_injection=1 halt_on_triple_fault=1
+    create: true
+  become: true


### PR DESCRIPTION
This PR should fix https://github.com/intel/ccc-linux-guest-hardening/issues/81

It adds a task in `bkc` role to append the following block in `/etc/modprobe.d/kvm-intel.conf` if not found:

```bash
# BEGIN ANSIBLE MANAGED BLOCK - ccc-linux-guest-hardening
options kvm-intel nested=1 ve_injection=1 halt_on_triple_fault=1
# END ANSIBLE MANAGED BLOCK - ccc-linux-guest-hardening
```