### PR TITLE
deploy: use master branch for kAFL collection

### DIFF
--- a/bkc/kafl/README.md
+++ b/bkc/kafl/README.md
@@ -12,7 +12,7 @@ __TODO:__ update and split out different example harnesses as subsections
 kAFL requires the guest OS to implements an 'agent' which communicates with
 the fuzzer using hypercalls and shared memory. There are two basic approaches.
 
-1. Boot to userspace and initiate the agent via cron/systemd and `kafl_fuzz.py -sharedir`
+1. Boot to userspace and initiate the agent via cron/systemd and `kafl fuzz -sharedir`
 2. Integrate the agent into the Linux kernel to start fuzzing before userspace is up
 
 For simpler first option is described below. 

--- a/bkc/kafl/fuzz.sh
+++ b/bkc/kafl/fuzz.sh
@@ -172,7 +172,7 @@ function run()
 	popd  > /dev/null
 
 	echo "Launching kAFL with workdir ${WORK_DIR}.."
-	kafl_fuzz.py \
+	kafl fuzz \
 		--memory $MEMSIZE \
 		-ip0 $ip0_a-$ip0_b \
 		-ip1 $ip1_a-$ip1_b \
@@ -195,7 +195,7 @@ function debug()
 	echo "Target kernel location:  $TARGET_BIN"
 	echo -e "\033[00m"
 
-	kafl_debug.py \
+	kafl debug \
 		--resume --memory $MEMSIZE \
 		--bios $BIOS_IMAGE \
 		--initrd $INITRD_IMAGE \
@@ -215,7 +215,7 @@ function single()
 
 	get_ip_regions
 
-	kafl_debug.py \
+	kafl debug \
 		--resume --memory $MEMSIZE \
 		-ip0 $ip0_a-$ip0_b \
 		-ip1 $ip1_a-$ip1_b \
@@ -246,7 +246,7 @@ function triage()
 
 	get_ip_regions
 
-	kafl_debug.py \
+	kafl debug \
 		--resume --memory $MEMSIZE \
 		-ip0 $ip0_a-$ip0_b \
 		-ip1 $ip1_a-$ip1_b \
@@ -273,7 +273,7 @@ function noise()
 	echo
 	sleep 1
 
-	kafl_debug.py \
+	kafl debug \
 		--resume --memory $MEMSIZE \
 		-ip0 $ip0_a-$ip0_b \
 		-ip1 $ip1_a-$ip1_b \
@@ -300,7 +300,7 @@ function cov()
 	echo "$ip2_a-$ip2_b ($ip2_name) // disabled"
 	sleep 2
 
-	kafl_cov.py \
+	kafl cov \
 		--resume --memory $MEMSIZE \
 		-ip0 $ip0_a-$ip0_b \
 		-ip1 $ip1_a-$ip1_b \

--- a/deploy/requirements.yml
+++ b/deploy/requirements.yml
@@ -2,4 +2,4 @@ collections:
   - name: intellabs.kafl
     source: git+https://github.com/IntelLabs/kAFL#/deploy/intellabs/
     type: git
-    version: stable-v0.5
+    version: master

--- a/deploy/roles/bkc/meta/main.yml
+++ b/deploy/roles/bkc/meta/main.yml
@@ -3,7 +3,8 @@ dependencies:
     tags:
       - fuzzer
     vars:
-      fuzzer_revision: kafl_tdx
+      fuzzer_url: https://github.com/Wenzel/kafl.fuzzer
+      fuzzer_revision: kafl_tdx_rebased
       qemu_revision: kafl_stable_tdx
       libxdc_revision: kafl_stable_tdx
       kernel_deb_urls:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -122,7 +122,7 @@ kafl_gui.py $KAFL_WORKDIR
 
 Review the `fuzz.sh` helper to get an idea for how this works. Generally, the
 script abstracts the most common usages of the kAFL fuzzer and ensures
-that each usage (`kafl_fuzz.py`, `kafl_cov.py`, `kafl_debug.py`) is called with
+that each usage (`kafl fuzz`, `kafl cov`, `kafl debug`) is called with
 the same consistent VM setup. Moreover, it prefers local files and arguments over
 global defaults to allow easy customization.
 

--- a/docs/kafl_agent.md
+++ b/docs/kafl_agent.md
@@ -91,7 +91,7 @@ Best known defaults are encoded in existing harness definitions in `bkc/kafl/run
 
 ### Logging and Debug
 
-Kernel printk facility is redirected to log messages via hypercalls (`kafl_hprintf()`). The loglevel can be set using `hprintf=` cmdline on kernel boot. For debugging, enable storing per-VM logs using `kafl_fuzz.py --log-hprintf` option. This can overflow a disk quickly, so normal fuzzing operation should be done with `--log-crashes`.
+Kernel printk facility is redirected to log messages via hypercalls (`kafl_hprintf()`). The loglevel can be set using `hprintf=` cmdline on kernel boot. For debugging, enable storing per-VM logs using `kafl fuzz --log-hprintf` option. This can overflow a disk quickly, so normal fuzzing operation should be done with `--log-crashes`.
 
 The kAFL agent also supports printing 3 types of debug/trace statistics. This is done only once for every new input found by the fuzzer, and enabled using a special `agent_flags` field in the payload buffer:
 * dump_stats - write a line of input injection stats at end of execution

--- a/docs/usermode_stimulus.md
+++ b/docs/usermode_stimulus.md
@@ -113,7 +113,7 @@ ln -sf  $BUILDROOT_VERSION/output/images/rootfs.cpio.gz $BKC_ROOT/initrd.cpio.gz
 ## Sharedir Setup
 
 The kAFL `sharedir` feature offers an OS-independent interface for downloading
-files from a host directory provided using the `kafl_fuzz.py --sharedir` option.
+files from a host directory provided using the `kafl fuzz --sharedir` option.
 
 By default, the stage 1 `loader.sh` uses `hget` to request and execute an
 `init.sh` script as the 2nd stage and perform actual harness initialization.

--- a/docs/workflow_overview.md
+++ b/docs/workflow_overview.md
@@ -110,7 +110,7 @@ which can then be mapped against the smatch audit lists (#1.1).
 
 There are multiple tools involved in this step:
 
-- `fuzz.sh cov` uses the `kafl_cov.py` tool to obtain the list of seen block
+- `fuzz.sh cov` uses the `kafl cov` tool to obtain the list of seen block
   transitions for a given corpus of inputs. The binary and decoded traces, and
   a summary of unique seen edges are stored to `<workdir>/traces`
 


### PR DESCRIPTION
This PR removes the pinning on [`stable-v0.5`](https://github.com/IntelLabs/kAFL/tree/stable-v0.5) branch for the kAFL Ansible collection and uses `master` instead.

See this ticket https://github.com/IntelLabs/kAFL/issues/184
The ccc repo's bkc role is already overriding the versions pinned by `stable-v0.5` anyway.

I also rebased kafl.fuzzer's [`kafl_tdx`](https://github.com/IntelLabs/kafl.fuzzer/tree/kafl_tdx) branch to `master`, these are the changes (99 commits, 42 files changed):
https://github.com/IntelLabs/kafl.fuzzer/compare/kafl_tdx...master

The main user interfaces changed are
- new kafl fuzzer command line, subcommand style: `kafl_fuzz.py` -> `kafl fuzz`, etc. see https://github.com/IntelLabs/kafl.fuzzer/pull/22
- using [dynaconf](https://www.dynaconf.com/) to handle kafl configuration. See the [kafl fuzzer documentation](https://intellabs.github.io/kAFL/reference/fuzzer_configuration.html)

The rebased branch has been pushed on my own fork under [`kafl_tdx_rebased`](https://github.com/Wenzel/kafl.fuzzer/tree/kafl_tdx_rebased) to avoid breaking anything while we work on this PR.



